### PR TITLE
Fix incorrect link to mybinder.org in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # rocker/binder
 
-Adds [binder](http://binder.org) abilities on top of the `rocker/tidyverse` images. 
+Adds [binder](http://mybinder.org/) abilities on top of the `rocker/tidyverse` images. 
 
 
 ## Deploy methods


### PR DESCRIPTION
I mess this URL up all the time.