### PR TITLE
Use a virtualenv to install python dependencies

### DIFF
--- a/3.3.1/Dockerfile
+++ b/3.3.1/Dockerfile
@@ -1,30 +1,48 @@
 FROM rocker/tidyverse:3.3.1
+
 ENV NB_USER rstudio
 ENV NB_UID 1000
+ENV VENV_DIR /srv/venv
+
+# Set ENV for all programs...
+ENV PATH ${VENV_DIR}/bin:$PATH
+# And set ENV for R! It doesn't read from the environment...
+RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron
+
+# The `rsession` binary that is called by nbrsessionproxy to start R doesn't seem to start
+# without this being explicitly set
+ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+
 ENV HOME /home/${NB_USER}
+WORKDIR ${HOME}
 
 RUN apt-get update && \
-    apt-get -y install python3-pip && \
-    pip3 install \
+    apt-get -y install python3-venv python3-dev && \
+    apt-get purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a venv dir owned by unprivileged user & set up notebook in it
+# This allows non-root to install python libraries if required
+RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
+
+USER ${NB_USER}
+RUN python3 -m venv ${VENV_DIR} && \
+    pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \
          git+https://github.com/jupyterhub/nbserverproxy.git@5508a182b2144d29824652d8977b32302517c8bc && \
-    apt-get purge && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
-
-USER ${NB_USER}    
-WORKDIR ${HOME}
-RUN R --quiet -e "IRkernel::installspec()" && \
-    jupyter serverextension enable --user --py nbserverproxy && \
-    jupyter serverextension enable --user --py nbrsessionproxy && \
-    jupyter nbextension install    --user --py nbrsessionproxy && \
-    jupyter nbextension enable     --user --py nbrsessionproxy
+    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+    jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension enable     --sys-prefix --py nbrsessionproxy
 
 
-## Does IRkernel not getting R_LIBS from .Renviron?
-ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+RUN R --quiet -e "devtools::install_github('IRkernel/IRkernel')" && \
+    R --quiet -e "IRkernel::installspec(prefix='${VENV_DIR}')"
 
 
 CMD jupyter notebook --ip 0.0.0.0
+
+
+## If extending this image, remember to switch back to USER root to apt-get

--- a/3.3.2/Dockerfile
+++ b/3.3.2/Dockerfile
@@ -1,29 +1,45 @@
 FROM rocker/tidyverse:3.3.2
+
 ENV NB_USER rstudio
 ENV NB_UID 1000
+ENV VENV_DIR /srv/venv
+
+# Set ENV for all programs...
+ENV PATH ${VENV_DIR}/bin:$PATH
+# And set ENV for R! It doesn't read from the environment...
+RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron
+
+# The `rsession` binary that is called by nbrsessionproxy to start R doesn't seem to start
+# without this being explicitly set
+ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+
 ENV HOME /home/${NB_USER}
+WORKDIR ${HOME}
 
 RUN apt-get update && \
-    apt-get -y install python3-pip && \
-    pip3 install \
+    apt-get -y install python3-venv python3-dev && \
+    apt-get purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a venv dir owned by unprivileged user & set up notebook in it
+# This allows non-root to install python libraries if required
+RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
+
+USER ${NB_USER}
+RUN python3 -m venv ${VENV_DIR} && \
+    pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \
          git+https://github.com/jupyterhub/nbserverproxy.git@5508a182b2144d29824652d8977b32302517c8bc && \
-    apt-get purge && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
+    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+    jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension enable     --sys-prefix --py nbrsessionproxy
 
-USER ${NB_USER}    
-WORKDIR ${HOME}
-RUN R --quiet -e "IRkernel::installspec()" && \
-    jupyter serverextension enable --user --py nbserverproxy && \
-    jupyter serverextension enable --user --py nbrsessionproxy && \
-    jupyter nbextension install    --user --py nbrsessionproxy && \
-    jupyter nbextension enable     --user --py nbrsessionproxy
 
-## Does IRkernel not getting R_LIBS from .Renviron?
-ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+RUN R --quiet -e "devtools::install_github('IRkernel/IRkernel')" && \
+    R --quiet -e "IRkernel::installspec(prefix='${VENV_DIR}')"
 
 
 CMD jupyter notebook --ip 0.0.0.0

--- a/3.3.3/Dockerfile
+++ b/3.3.3/Dockerfile
@@ -1,29 +1,48 @@
 FROM rocker/tidyverse:3.3.3
+
 ENV NB_USER rstudio
 ENV NB_UID 1000
+ENV VENV_DIR /srv/venv
+
+# Set ENV for all programs...
+ENV PATH ${VENV_DIR}/bin:$PATH
+# And set ENV for R! It doesn't read from the environment...
+RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron
+
+# The `rsession` binary that is called by nbrsessionproxy to start R doesn't seem to start
+# without this being explicitly set
+ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+
 ENV HOME /home/${NB_USER}
+WORKDIR ${HOME}
 
 RUN apt-get update && \
-    apt-get -y install python3-pip && \
-    pip3 install \
+    apt-get -y install python3-venv python3-dev && \
+    apt-get purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a venv dir owned by unprivileged user & set up notebook in it
+# This allows non-root to install python libraries if required
+RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
+
+USER ${NB_USER}
+RUN python3 -m venv ${VENV_DIR} && \
+    pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \
          git+https://github.com/jupyterhub/nbserverproxy.git@5508a182b2144d29824652d8977b32302517c8bc && \
-    apt-get purge && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
+    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+    jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension enable     --sys-prefix --py nbrsessionproxy
 
-USER ${NB_USER}    
-WORKDIR ${HOME}
-RUN R --quiet -e "IRkernel::installspec()" && \
-    jupyter serverextension enable --user --py nbserverproxy && \
-    jupyter serverextension enable --user --py nbrsessionproxy && \
-    jupyter nbextension install    --user --py nbrsessionproxy && \
-    jupyter nbextension enable     --user --py nbrsessionproxy
 
-## Does IRkernel not getting R_LIBS from .Renviron?
-ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+RUN R --quiet -e "devtools::install_github('IRkernel/IRkernel')" && \
+    R --quiet -e "IRkernel::installspec(prefix='${VENV_DIR}')"
 
 
 CMD jupyter notebook --ip 0.0.0.0
+
+
+## If extending this image, remember to switch back to USER root to apt-get

--- a/3.4.0/Dockerfile
+++ b/3.4.0/Dockerfile
@@ -1,30 +1,48 @@
 FROM rocker/tidyverse:3.4.0
+
 ENV NB_USER rstudio
 ENV NB_UID 1000
+ENV VENV_DIR /srv/venv
+
+# Set ENV for all programs...
+ENV PATH ${VENV_DIR}/bin:$PATH
+# And set ENV for R! It doesn't read from the environment...
+RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron
+
+# The `rsession` binary that is called by nbrsessionproxy to start R doesn't seem to start
+# without this being explicitly set
+ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+
 ENV HOME /home/${NB_USER}
+WORKDIR ${HOME}
 
 RUN apt-get update && \
-    apt-get -y install python3-pip && \
-    pip3 install \
+    apt-get -y install python3-venv python3-dev && \
+    apt-get purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a venv dir owned by unprivileged user & set up notebook in it
+# This allows non-root to install python libraries if required
+RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
+
+USER ${NB_USER}
+RUN python3 -m venv ${VENV_DIR} && \
+    pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \
          git+https://github.com/jupyterhub/nbserverproxy.git@5508a182b2144d29824652d8977b32302517c8bc && \
-    apt-get purge && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
-
-USER ${NB_USER}    
-WORKDIR ${HOME}
-RUN R --quiet -e "IRkernel::installspec()" && \
-    jupyter serverextension enable --user --py nbserverproxy && \
-    jupyter serverextension enable --user --py nbrsessionproxy && \
-    jupyter nbextension install    --user --py nbrsessionproxy && \
-    jupyter nbextension enable     --user --py nbrsessionproxy
+    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+    jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension enable     --sys-prefix --py nbrsessionproxy
 
 
-## Does IRkernel not getting R_LIBS from .Renviron?
-ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+RUN R --quiet -e "devtools::install_github('IRkernel/IRkernel')" && \
+    R --quiet -e "IRkernel::installspec(prefix='${VENV_DIR}')"
 
 
 CMD jupyter notebook --ip 0.0.0.0
+
+
+## If extending this image, remember to switch back to USER root to apt-get

--- a/3.4.1/Dockerfile
+++ b/3.4.1/Dockerfile
@@ -1,34 +1,48 @@
 FROM rocker/tidyverse:3.4.1
+
 ENV NB_USER rstudio
 ENV NB_UID 1000
+ENV VENV_DIR /srv/venv
+
+# Set ENV for all programs...
+ENV PATH ${VENV_DIR}/bin:$PATH
+# And set ENV for R! It doesn't read from the environment...
+RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron
+
+# The `rsession` binary that is called by nbrsessionproxy to start R doesn't seem to start
+# without this being explicitly set
+ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+
 ENV HOME /home/${NB_USER}
+WORKDIR ${HOME}
 
 RUN apt-get update && \
-    apt-get -y install python3-pip && \
+    apt-get -y install python3-venv python3-dev && \
+    apt-get purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a venv dir owned by unprivileged user & set up notebook in it
+# This allows non-root to install python libraries if required
+RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
+
+USER ${NB_USER}
+RUN python3 -m venv ${VENV_DIR} && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \
          git+https://github.com/jupyterhub/nbserverproxy.git@5508a182b2144d29824652d8977b32302517c8bc && \
-    apt-get purge && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
-
-USER ${NB_USER}    
-WORKDIR ${HOME}
-RUN R --quiet -e "IRkernel::installspec()" && \
-    jupyter serverextension enable --user --py nbserverproxy && \
-    jupyter serverextension enable --user --py nbrsessionproxy && \
-    jupyter nbextension install    --user --py nbrsessionproxy && \
-    jupyter nbextension enable     --user --py nbrsessionproxy
+    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+    jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension enable     --sys-prefix --py nbrsessionproxy
 
 
-# Run install.r if it exists
-COPY . /tmp 
-RUN if [ -f /tmp/install.R ]; then R --quiet -f /tmp/install.r; fi
-
-## Does IRkernel not getting R_LIBS from .Renviron?
-ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+RUN R --quiet -e "devtools::install_github('IRkernel/IRkernel')" && \
+    R --quiet -e "IRkernel::installspec(prefix='${VENV_DIR}')"
 
 
 CMD jupyter notebook --ip 0.0.0.0
+
+
+## If extending this image, remember to switch back to USER root to apt-get

--- a/3.4.2/Dockerfile
+++ b/3.4.2/Dockerfile
@@ -1,34 +1,48 @@
 FROM rocker/tidyverse:3.4.2
+
 ENV NB_USER rstudio
 ENV NB_UID 1000
+ENV VENV_DIR /srv/venv
+
+# Set ENV for all programs...
+ENV PATH ${VENV_DIR}/bin:$PATH
+# And set ENV for R! It doesn't read from the environment...
+RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron
+
+# The `rsession` binary that is called by nbrsessionproxy to start R doesn't seem to start
+# without this being explicitly set
+ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+
 ENV HOME /home/${NB_USER}
+WORKDIR ${HOME}
 
 RUN apt-get update && \
-    apt-get -y install python3-pip && \
+    apt-get -y install python3-venv python3-dev && \
+    apt-get purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a venv dir owned by unprivileged user & set up notebook in it
+# This allows non-root to install python libraries if required
+RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
+
+USER ${NB_USER}
+RUN python3 -m venv ${VENV_DIR} && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \
          git+https://github.com/jupyterhub/nbserverproxy.git@5508a182b2144d29824652d8977b32302517c8bc && \
-    apt-get purge && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
-
-USER ${NB_USER}    
-WORKDIR ${HOME}
-RUN R --quiet -e "IRkernel::installspec()" && \
-    jupyter serverextension enable --user --py nbserverproxy && \
-    jupyter serverextension enable --user --py nbrsessionproxy && \
-    jupyter nbextension install    --user --py nbrsessionproxy && \
-    jupyter nbextension enable     --user --py nbrsessionproxy
+    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+    jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension enable     --sys-prefix --py nbrsessionproxy
 
 
-# Run install.r if it exists
-COPY . /tmp 
-RUN if [ -f /tmp/install.R ]; then R --quiet -f /tmp/install.r; fi
-
-## Does IRkernel not getting R_LIBS from .Renviron?
-ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+RUN R --quiet -e "devtools::install_github('IRkernel/IRkernel')" && \
+    R --quiet -e "IRkernel::installspec(prefix='${VENV_DIR}')"
 
 
 CMD jupyter notebook --ip 0.0.0.0
+
+
+## If extending this image, remember to switch back to USER root to apt-get

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,53 @@
 FROM rocker/tidyverse:latest
 ENV NB_USER rstudio
 ENV NB_UID 1000
+ENV VENV_DIR /srv/venv
+ENV PATH ${VENV_DIR}/bin:$PATH
+
+# The `rsession` binary that is called by nbrsessionproxy to start R doesn't seem to start
+# without this being explicitly set
+ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+
 ENV HOME /home/${NB_USER}
+WORKDIR ${HOME}
 
 RUN apt-get update && \
-    apt-get -y install python3-pip && \
+    apt-get -y install python3-venv python3-dev && \
+    apt-get purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a venv dir owned by unprivileged user & set up notebook in it
+# This allows non-root to install python libraries if required
+RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
+
+USER ${NB_USER}
+RUN python3 -m venv ${VENV_DIR} && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \
          git+https://github.com/jupyterhub/nbserverproxy.git@5508a182b2144d29824652d8977b32302517c8bc && \
-    apt-get purge && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
+    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+    jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension enable     --sys-prefix --py nbrsessionproxy
 
 
-## These commands must be run in $HOME by $NB_USER, with $NB_UID already set
-## note: for some reason, just doing in a root run command with su ${NB_USER}
-USER ${NB_USER}
-WORKDIR ${HOME} 
+RUN R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
 
-## Magic to allow JupyterHub to manage arbitrary sessions, including RStudio
-RUN  R --quiet -e "IRkernel::installspec()" && \
-    jupyter serverextension enable --user --py nbserverproxy && \
-    jupyter serverextension enable --user --py nbrsessionproxy && \
-    jupyter nbextension install    --user --py nbrsessionproxy && \
-    jupyter nbextension enable     --user --py nbrsessionproxy
+# For some reason, R doesn't seem to want to interpret PATH from the environment!
+#
+#   rstudio@32b818e938c3:~$ echo $PATH
+#   /srv/venv/bin:/usr/lib/rstudio-server/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+#   rstudio@32b818e938c3:~$ R --quiet -e 'Sys.getenv("PATH")'
+#   > Sys.getenv("PATH")
+#   [1] "/usr/lib/rstudio-server/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+#
+# This causes it to never find the `jupyter` script in ${VENV_DIR}/bin.
+# This is the only hack that seems to work.
+RUN R --quiet -e "Sys.setenv(PATH='${PATH}'); IRkernel::installspec(prefix='${VENV_DIR}')"
 
-## Is IRkernel not getting R_LIBS from .Renviron?
-ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+
 
 
 CMD jupyter notebook --ip 0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM rocker/tidyverse:latest
+
 ENV NB_USER rstudio
 ENV NB_UID 1000
 ENV VENV_DIR /srv/venv


### PR DESCRIPTION
- Isolates it from base image python dependencies. Mixing apt
  and pip for python dependencies always causes problems at
  some point :)
- Allows users to install python packages as unprivileged users
- Hack way around R apparently not picking up PATH from environment