### PR TITLE
Explicitly pin version of pip in Dockerfile

### DIFF
--- a/3.3.1/Dockerfile
+++ b/3.3.1/Dockerfile
@@ -28,6 +28,8 @@ RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
 
 USER ${NB_USER}
 RUN python3 -m venv ${VENV_DIR} && \
+    # Explicitly install a new enough version of pip
+    pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \

--- a/3.3.2/Dockerfile
+++ b/3.3.2/Dockerfile
@@ -28,6 +28,8 @@ RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
 
 USER ${NB_USER}
 RUN python3 -m venv ${VENV_DIR} && \
+    # Explicitly install a new enough version of pip
+    pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \
@@ -43,3 +45,6 @@ RUN R --quiet -e "devtools::install_github('IRkernel/IRkernel')" && \
 
 
 CMD jupyter notebook --ip 0.0.0.0
+
+
+## If extending this image, remember to switch back to USER root to apt-get

--- a/3.3.3/Dockerfile
+++ b/3.3.3/Dockerfile
@@ -28,6 +28,8 @@ RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
 
 USER ${NB_USER}
 RUN python3 -m venv ${VENV_DIR} && \
+    # Explicitly install a new enough version of pip
+    pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \

--- a/3.4.0/Dockerfile
+++ b/3.4.0/Dockerfile
@@ -28,6 +28,8 @@ RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
 
 USER ${NB_USER}
 RUN python3 -m venv ${VENV_DIR} && \
+    # Explicitly install a new enough version of pip
+    pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \

--- a/3.4.1/Dockerfile
+++ b/3.4.1/Dockerfile
@@ -28,6 +28,8 @@ RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
 
 USER ${NB_USER}
 RUN python3 -m venv ${VENV_DIR} && \
+    # Explicitly install a new enough version of pip
+    pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
 
 USER ${NB_USER}
 RUN python3 -m venv ${VENV_DIR} && \
+    # Explicitly install a new enough version of pip
+    pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
          git+https://github.com/jupyterhub/nbrsessionproxy.git@6eefeac11cbe82432d026f41a3341525a22d6a0b \


### PR DESCRIPTION
This upgrades pip versions on Debian Jessie based images to a
new enough version to get --no-cache-dir (and wheel support)

Fixes #6