### PR TITLE
Upgrade version of nbrsessionproxy

### DIFF
--- a/3.3.1/Dockerfile
+++ b/3.3.1/Dockerfile
@@ -32,9 +32,7 @@ RUN python3 -m venv ${VENV_DIR} && \
     pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
-         nbserverproxy==0.3.1 \
-         nbrsessionproxy==0.3.1 && \
-    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+         nbrsessionproxy==0.4.1 && \
     jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension enable     --sys-prefix --py nbrsessionproxy

--- a/3.3.2/Dockerfile
+++ b/3.3.2/Dockerfile
@@ -32,9 +32,7 @@ RUN python3 -m venv ${VENV_DIR} && \
     pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
-         nbserverproxy==0.3.1 \
-         nbrsessionproxy==0.3.1 && \
-    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+         nbrsessionproxy==0.4.1 && \
     jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension enable     --sys-prefix --py nbrsessionproxy

--- a/3.3.3/Dockerfile
+++ b/3.3.3/Dockerfile
@@ -32,9 +32,7 @@ RUN python3 -m venv ${VENV_DIR} && \
     pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
-         nbserverproxy==0.3.1 \
-         nbrsessionproxy==0.3.1 && \
-    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+         nbrsessionproxy==0.4.1 && \
     jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension enable     --sys-prefix --py nbrsessionproxy

--- a/3.4.0/Dockerfile
+++ b/3.4.0/Dockerfile
@@ -32,9 +32,7 @@ RUN python3 -m venv ${VENV_DIR} && \
     pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
-         nbserverproxy==0.3.1 \
-         nbrsessionproxy==0.3.1 && \
-    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+         nbrsessionproxy==0.4.1 && \
     jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension enable     --sys-prefix --py nbrsessionproxy

--- a/3.4.1/Dockerfile
+++ b/3.4.1/Dockerfile
@@ -32,9 +32,7 @@ RUN python3 -m venv ${VENV_DIR} && \
     pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
-         nbserverproxy==0.3.1 \
-         nbrsessionproxy==0.3.1 && \
-    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+         nbrsessionproxy==0.4.1 && \
     jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension enable     --sys-prefix --py nbrsessionproxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,7 @@ RUN python3 -m venv ${VENV_DIR} && \
     pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
          notebook==5.2 \
-         nbserverproxy==0.3.1 \
-         nbrsessionproxy==0.3.1 && \
-    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+         nbrsessionproxy==0.4.1 && \
     jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
     jupyter nbextension enable     --sys-prefix --py nbrsessionproxy


### PR DESCRIPTION
- Adds support for switching projects & git operations in
  rstudio
- Proxies rstudio entirely consistently under '/rstudio' rather
  than redirecting to a random URL every time
- Removes nbserverproxy as an explicit dependency, since this is
  now managed by nbrsessionproxy now

Fixes #10 