### PR TITLE
avoid invalidating install.R cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ repository:
 ```bash
 FROM rocker/binder:3.4.2
 
+## Run an install.R script, if it exists.
+RUN if [ -f install.R ]; then R --quiet -f install.R; fi
+
 ## Copies your repo files into the Docker Container
 USER root
 COPY . ${HOME}
@@ -34,9 +37,6 @@ RUN chown -R ${NB_USER} ${HOME}
 
 ## Become normal user again
 USER ${NB_USER}
-
-## Run an install.R script, if it exists.
-RUN if [ -f install.R ]; then R --quiet -f install.R; fi
 
 ```
 


### PR DESCRIPTION
Assuming dependencies in the `install.R` script change less frequently than repo data, placing that layer first would help images build faster. If the repo data are really heavy the user would want to reverse it.