### PR TITLE
Pin to older rsession-proxy to work with R < 4.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,16 +29,18 @@ RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
 
 USER ${NB_USER}
 RUN python3 -m venv ${VENV_DIR} && \
-    # Explicitly install a new enough version of pip
+    # Explicitly install a new enough version of pip, as the base version is too old
     pip3 install pip==9.0.1 && \
     pip3 install --no-cache-dir \
-         jupyter-rsession-proxy
+        # This is for R 3.6 + older version of RStudio, so we need older
+        # version of jupyter-rsession-proxy.
+        jupyter-rsession-proxy<2.0 notebook
 
 RUN R --quiet -e "devtools::install_github('IRkernel/IRkernel')" && \
     R --quiet -e "IRkernel::installspec(prefix='${VENV_DIR}')"
 
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD jupyter server --ip 0.0.0.0
 
 
 ## If extending this image, remember to switch back to USER root to apt-get


### PR DESCRIPTION
This repo no longer builds newer versions of
https://hub.docker.com/r/rocker/binder - those come from
https://github.com/rocker-org/rocker-versioned2.
I've an example template that works in https://github.com/yuvipanda/rocker-binder-template.

This repo builds the images where R < 4.x. Needed a few changes
to work:

1. Pin to older jupyter-rsession-proxy. Newer version only works
   with newer RStudio
2. Explicitly install notebook package, as jupyter-rsession-proxy
   no longer brings that in by default
3. Use jupyter server as the command to start, rather than jupyter
   notebook. This should have no functional difference, but it means
   you can remove the notebook package if you don't want to use
   jupyter notebooks.

Ref https://github.com/rocker-org/rocker-versioned2/issues/147