### PR TITLE
avoid setting xdg_data_home

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,7 @@ on:
       - Dockerfile
       - environment.yml
       - install.r
+      - vscode-extensions.txt
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE=quay.io/jupyter/minimal-notebook:ubuntu-24.04
 FROM $BASE
 
-# Make code-server extensions etc persist to container, not hub
-ENV XDG_DATA_HOME=/opt/share
+# this env var is recognized by jupyter-vscode-proxy:
+ENV CODE_EXTENSIONSDIR=/opt/share/code-server
 ## Add rstudio's binaries to path for quarto
 ENV PATH=$PATH:/usr/lib/rstudio-server/bin/quarto/bin
 
@@ -23,7 +23,7 @@ RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/in
 USER ${NB_USER}
 
 COPY vscode-extensions.txt /tmp/vscode-extensions.txt
-RUN xargs -n 1 code-server --install-extension < /tmp/vscode-extensions.txt
+RUN xargs -n 1 code-server --extensions-dir ${CODE_EXTENSIONSDIR}  --install-extension < /tmp/vscode-extensions.txt
 
 COPY environment.yml /tmp/environment.yml
 RUN conda update --all --solver=classic -n base -c conda-forge conda && \

--- a/vscode-extensions.txt
+++ b/vscode-extensions.txt
@@ -1,8 +1,9 @@
+alefragnani.project-manager
+cline.cline
 ms-python.python
 ms-toolsai.jupyter
 ms-vscode.live-server
-quarto.quarto
 posit.shiny
+quarto.quarto
 reditorsupport.r
-continue.continue
-alefragnani.project-manager
+

--- a/vscode-extensions.txt
+++ b/vscode-extensions.txt
@@ -1,9 +1,8 @@
 alefragnani.project-manager
-cline.cline
 ms-python.python
 ms-toolsai.jupyter
 ms-vscode.live-server
 posit.shiny
 quarto.quarto
 reditorsupport.r
-
+saoudrizwan.claude-dev


### PR DESCRIPTION
Use env var recognized by jupyter-vscode-proxy to set extensions dir.  allows preinstalled extensions, but persistent configuration.  